### PR TITLE
New feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 bower_components
 reports
 dist/_bower.js
+.idea/

--- a/example/index.html
+++ b/example/index.html
@@ -30,14 +30,24 @@
     <form>
       <input type="text" id="date-picker" data-pickr data-pickr-format="%Y-%m-%d" placeholder="Select a date"/>
     </form>
-    <script src="../bower_components/jquery/jquery.js"></script>
+    <div>
+      <h1>Inline example</h1>
+      <div id="inline"></div>
+    </div>
+    <script src="../bower_components/jquery/dist/jquery.js"></script>
     <script src="../bower_components/fidel/dist/fidel.js" data-cover></script>
     <script src="../bower_components/template/dist/template.js"></script>
     <script src="../bower_components/fidel-template/dist/fidel-template.js"></script>
     <script src="../lib/timeformat.js" data-cover></script>
     <script src="../dist/fidel.pickr.js" data-cover></script>
     <script>
-      $('#date-picker').pickr();
+      $('#date-picker').pickr().on('pickr:selected', function (e, date) {
+        console.log('New date selected:', date);
+      });
+      $('#inline').pickr().on('pickr:selected', function (e, date) {
+        console.log('New date selected:', date);
+      });
+
     </script>
   </body>
 </html>

--- a/lib/pickr.js
+++ b/lib/pickr.js
@@ -11,13 +11,15 @@
       currentMonth: new Date(),
       dayLabels: ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'],
       dateFormat: '%Y-%m-%d',
-      allowPastDays: true
+      allowPastDays: true,
+      inline: false
     },
 
     init: function() {
       this.el.addClass('pickr');
       this.pickrContainer = $('<div></div>').addClass('pickr-container');
       this.el.after(this.pickrContainer);
+      this.inline = this.el.prop('tagName').toLowerCase() !== 'input' || this.inline;
       this.focus = false;
 
       if(this.el.data('pickr-format')) {
@@ -25,11 +27,18 @@
       }
 
       this.bindEvents();
+
+      if (this.inline) {
+        this.showModal();
+      }
     },
 
     bindEvents: function() {
-      this.el.on('focus', this.proxy(this.showModal));
-      this.el.on('blur', this.proxy(this.hideModal));
+      if (!this.inline){
+        this.el.on('focus', this.proxy(this.showModal));
+        this.el.on('blur', this.proxy(this.hideModal));
+      }
+
       this.pickrContainer.on('click', this.proxy(this.containerClicked));
       this.pickrContainer.on('click', '*', this.proxy(this.containerClicked));
     },
@@ -86,7 +95,10 @@
       clearTimeout(this.hideTimer);
       
       this.focus = true;
-      this.el.focus();
+
+      if (!this.inline) {
+        this.el.focus();
+      }
 
       var target = $(event.target);
 
@@ -111,9 +123,14 @@
     },
 
     selectDate: function(date) {
-      this.el.val(TimeFormat(this.dateFormat, date));
-      this.el.trigger('input');
-      this.el.blur();
+      var value = TimeFormat(this.dateFormat, date);
+      this.el.trigger('pickr:selected', value);
+
+      if (!this.inline){
+        this.el.val(value);
+        this.el.trigger('input');
+        this.el.blur();
+      }
     },
 
     daysInMonth: function(date) {

--- a/test/index.html
+++ b/test/index.html
@@ -20,7 +20,7 @@
       <input type="text" id="date-picker" data-pickr data-pickr-format="%Y-%m-%d" />
     </form>
   </div>
-  <script src="../bower_components/jquery/jquery.js"></script>
+  <script src="../bower_components/jquery/dist/jquery.js"></script>
   <script src="../bower_components/fidel/dist/fidel.js" data-cover></script>
   <script src="../bower_components/template/dist/template.js"></script>
   <script src="../bower_components/fidel-template/dist/fidel-template.js"></script>

--- a/test/index.html
+++ b/test/index.html
@@ -17,7 +17,8 @@
   <div id="mocha"></div>
   <div id="fixture" style="display: block">
     <form>
-      <input type="text" id="date-picker" data-pickr data-pickr-format="%Y-%m-%d" />
+      <input type="text" id="date-picker" class="test-subject" data-pickr data-pickr-format="%Y-%m-%d" />
+      <div id="inline" class="test-subject"></div>
     </form>
   </div>
   <script src="../bower_components/jquery/dist/jquery.js"></script>

--- a/test/pickr.test.js
+++ b/test/pickr.test.js
@@ -1,4 +1,6 @@
 var clickTimeout = 210;
+var monthNames = [ "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December" ];
 
 suite('pickr', function() {
   teardown(function(){
@@ -107,8 +109,13 @@ suite('pickr', function() {
       el.focus();
 
       $('.pickr-day').first().click();
+      var month = date.getMonth() + 1;
 
-      assert.equal(el.val(), date.getFullYear() + '-' + (date.getMonth() + 1) + '-01');
+      if (month < 10){
+        month = '0' + month;
+      }
+
+      assert.equal(el.val(), date.getFullYear() + '-' + month + '-01');
 
       setTimeout(function(){
         assert.ok(!$('.pickr-container').is(':empty'));
@@ -127,7 +134,7 @@ suite('pickr', function() {
 
       $('.pickr-prev-month').click();
 
-      assert.equal($.trim($('.pickr-month-title').first().text()), 'October');
+      assert.ok($.trim($('.pickr-month-title').first().text()).indexOf('October') > -1);
     });
 
     test('clicking next arrow should advance month', function() {
@@ -141,7 +148,7 @@ suite('pickr', function() {
 
       $('.pickr-next-month').click();
 
-      assert.equal($.trim($('.pickr-month-title').first().text()), 'December');
+      assert.ok($.trim($('.pickr-month-title').first().text()).indexOf('December') > -1);
     });
 
     test('clicking month title should go to today', function() {
@@ -156,7 +163,7 @@ suite('pickr', function() {
       $('.pickr-prev-month').click();
       $('.pickr-month-title').click();
 
-      assert.equal($.trim($('.pickr-month-title').first().text()), 'November');
+      assert.equal($.trim($('.pickr-month-title').first().text()), monthNames[new Date().getMonth()]);
     });
   });
 

--- a/test/pickr.test.js
+++ b/test/pickr.test.js
@@ -5,11 +5,11 @@ var monthNames = [ "January", "February", "March", "April", "May", "June",
 suite('pickr', function() {
   teardown(function(){
     $('.pickr-container').remove();
-    var el = $('#date-picker');
-    el.unbind();
-    el.removeData();
-    el.val('');
-    el.blur();
+    var els = $('.test-subject');
+    els.unbind();
+    els.removeData();
+    els.val('');
+    els.blur();
   });
 
   suite('init', function() {
@@ -23,6 +23,45 @@ suite('pickr', function() {
       el.pickr();
 
       assert.ok(el.hasClass('pickr'));
+    });
+
+    test('pickr class on div', function () {
+      var el = $('#inline');
+
+      el.pickr();
+
+      assert.ok(el.hasClass('pickr'));
+      assert.ok(el.next().attr('style') !== '');
+      assert.ok(el.next().hasClass('pickr-container'));
+    });
+  });
+
+  suite('Event binding', function () {
+    test('pickr should bind to focus and blur on the element and click on the container', function () {
+      var el = $('#date-picker'),
+        container, elEvents, containerEvents;
+
+      el.pickr();
+      container = el.next();
+      elEvents = $._data(el.get(0), 'events');
+      containerEvents = $._data(container.get(0), 'events');
+
+      assert.equal(elEvents.focus.length, 1);
+      assert.equal(elEvents.blur.length, 1);
+      assert.equal(containerEvents.click.length, 2);
+    });
+    test('pickr should not bind to focus and blur on an inline element but yes on click on the container', function () {
+      var el = $('#inline'),
+        container, elEvents, containerEvents;
+
+      el.pickr();
+      container = el.next();
+      elEvents = $._data(el.get(0), 'events');
+      containerEvents = $._data(container.get(0), 'events');
+
+      assert.ok(typeof elEvents.focus === 'undefined');
+      assert.ok(typeof elEvents.blur === 'undefined');
+      assert.equal(containerEvents.click.length, 2);
     });
   });
 
@@ -121,6 +160,27 @@ suite('pickr', function() {
         assert.ok(!$('.pickr-container').is(':empty'));
         done();
       }, clickTimeout);
+    });
+
+    test('selecting a date should fire a custom event', function (done) {
+      var el = $('#date-picker');
+
+      var date = new Date();
+      el.pickr();
+      el.focus();
+
+      var month = date.getMonth() + 1;
+
+      if (month < 10){
+        month = '0' + month;
+      }
+
+      el.on('pickr:selected', function (e, value) {
+        assert.equal(value, date.getFullYear() + '-' + month + '-01');
+        done();
+      });
+
+      $('.pickr-day').first().click();
     });
 
     test('clicking previous arrow should change month back', function() {


### PR DESCRIPTION
Pickr now can be shown inline. When pickr is attached to a DOM element that's not an input, it will activate the inline mode automatically.

It can also be forced with the option `inline` to `true`.

To be able to catch the value when on inline mode, pickr now triggers a `pickr:selected` event with the value as a parameter.

Note that the event is triggered both on inline and in normal mode.

Fixes #8
